### PR TITLE
fix: refresh timestamp shortcuts and empty block inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The behavior will be the same as for the Journal page: Only top-level child bloc
 
 ![interstial journal example](./img/journal.png)
 
-- By default, you can use `Ctrl-t` to insert a timestamp in the current block/line.
+- By default, you can use `mod+t` (`Ctrl+t` on Windows/Linux, `Cmd+t` on macOS) to insert a timestamp in the current block/line.
 
 ### Configuration
 

--- a/index.ts
+++ b/index.ts
@@ -8,8 +8,12 @@ interface PluginSettings {
   timestampShortcut: string;
 }
 
+type LogseqAppWithUnregister = typeof logseq.App & {
+  unregister_plugin_simple_command?: (key: string) => void;
+};
 
 const pluginName = ["logseq-interstitial", "Logseq Interstitial"]
+const timestampShortcutCommandKey = "insert-interstitial-timestamp"
 const settingsTemplate: SettingSchemaDesc[] = [
   {
     key: "timestampTopLevel",
@@ -34,6 +38,37 @@ const settingsTemplate: SettingSchemaDesc[] = [
   }
 ]
 logseq.useSettingsSchema(settingsTemplate)
+
+function getTimestampShortcut(settings: PluginSettings): string {
+  const shortcut = typeof settings.timestampShortcut === "string"
+    ? settings.timestampShortcut.trim().toLowerCase()
+    : "";
+
+  return shortcut !== "" ? shortcut : "mod+t";
+}
+
+function registerTimestampShortcut(settings: PluginSettings) {
+  logseq.App.registerCommandPalette(
+    {
+      key: timestampShortcutCommandKey,
+      label: "Insert interstitial timestamp",
+      keybinding: {
+        mode: "global",
+        binding: getTimestampShortcut(settings),
+      },
+    },
+    async () => {
+      await insertInterstitional();
+    }
+  );
+}
+
+function unregisterTimestampShortcut() {
+  // The shortcut is keyed under the plugin id; remove the old binding before re-registering.
+  (logseq.App as LogseqAppWithUnregister).unregister_plugin_simple_command?.(
+    `${logseq.baseInfo.id}/${timestampShortcutCommandKey}`
+  );
+}
 
 function buildRegexFromFormat(format: string): RegExp {
   const tokenMap: Record<string, string> = {
@@ -86,6 +121,12 @@ async function updateBlock(block: BlockEntity, update: boolean = false) {
 
   const hasRealContent = cleanedContent.length > 0;
   const isAlreadyStamped = timeRegex.test(block.content);
+  const isEmptyBlock = contentWithoutTimestamp.trim() === "";
+
+  if (update && isEmptyBlock && !isAlreadyStamped) {
+    await logseq.Editor.updateBlock(block.uuid, timeMarkup);
+    return;
+  }
 
   if ((update && hasRealContent) || (!isAlreadyStamped && hasRealContent)) {
     await logseq.Editor.updateBlock(
@@ -139,6 +180,9 @@ const main = async () => {
     throw new Error("logseq.settings is not defined!");
   }
 
+  const settings = logseq.settings as unknown as PluginSettings;
+  let registeredTimestampShortcut = getTimestampShortcut(settings);
+
   logseq.Editor.registerSlashCommand('Mark as Interstitial Template', async () => {
     const block = await logseq.Editor.getCurrentBlock();
     if (block?.uuid) {
@@ -146,12 +190,18 @@ const main = async () => {
     }
   });
 
-  logseq.App.registerCommandShortcut(
-    { binding: logseq.settings?.timestampShortcut as string },
-    () => {
-      insertInterstitional()
+  registerTimestampShortcut(settings);
+
+  logseq.onSettingsChanged((updatedSettings) => {
+    const nextShortcut = getTimestampShortcut(updatedSettings as unknown as PluginSettings);
+    if (nextShortcut === registeredTimestampShortcut) {
+      return;
     }
-  );
+
+    unregisterTimestampShortcut();
+    registerTimestampShortcut(updatedSettings as unknown as PluginSettings);
+    registeredTimestampShortcut = nextShortcut;
+  });
 
   logseq.DB.onChanged((e) => {
     if (e.txMeta?.outlinerOp == "save-block" || e.txMeta?.outlinerOp == "saveBlock") {


### PR DESCRIPTION
Replaces #5 so the changes are no longer tied to FelixHuoEZ/main.

## Summary
- refresh command palette shortcut bindings when the setting changes
- allow timestamp insertion into an empty block without requiring pre-existing content

## Notes
- same code changes as #5, but from a dedicated branch instead of main